### PR TITLE
Refresh site styling with editorial cartographic theme

### DIFF
--- a/docs/galleries/index.md
+++ b/docs/galleries/index.md
@@ -1,4 +1,4 @@
-# Map collections 🗺️
+# Map collections
 
 Every November the #30DayMapChallenge community creates tens of thousands of
 maps. This page links to **map collections** — galleries, portfolios and

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,13 +10,13 @@ The challenge takes place every November, with 30 different mapping themes - one
 
 The idea is to create maps based around different themes each day of November using the hashtag `#30DayMapChallenge`. You can prepare the maps beforehand, but the main idea is to publish maps on the dedicated days. Just include a picture of the map when you post to X/Instagram/Linkedin (or your preferred social media platforms) using the hashtag. You don't have to sign up anywhere to participate. There are no restrictions on the tools, technologies or the data you use in your maps. Doing less than 30 is also fine. See the *Code of Conduct* at the bottom of the page.
 
-## Explore the maps 🗺️
+## Explore the maps
 
 Every November mappers around the world share tens of thousands of maps. Browse the growing list of community **[map collections](galleries/index.md)** to get inspired — and [add your own](galleries/index.md) so others can find it too.
 
-## Data 🗺
+## Data
 
-You can use **whatever data you want.** But here are a few sources which could help you to get started or give you new ideas 👇
+You can use **whatever data you want.** Here are a few sources which could help you to get started or give you new ideas.
 
 - [OpenStreetMap](https://www.openstreetmap.org/)
 	- OpenStreetMap (OSM) is a collaborative project to create a free editable map of the world. If you seek for easy ways to get an extract of the data, you can check for [GeoFabrik](https://www.geofabrik.de/data/download.html) for Shapefiles  or [Overpass API for GeoJSONs etc.](https://overpass-turbo.eu/).
@@ -41,7 +41,7 @@ You can use **whatever data you want.** But here are a few sources which could h
 - [Data is Plural](https://www.data-is-plural.com/)
 	- The best data newsletter out there with an awesome archive including also some very obscure datasets. 
 
-## Tools 🔨🔧
+## Tools
 
 The challenge is open to any software, but here's a list of popular open-source tools to consider. No programming skills are required. Or if you are a programmer, no design skills are required. 
 
@@ -68,7 +68,7 @@ The challenge is open to any software, but here's a list of popular open-source 
  - [Observable](https://observablehq.com)
 	 - Reactive notebook environment for generation of visualization and cartographic output embedded in a textual narrative. Focus is on using [d3](https://d3js.org) for specifying visual output.
 
-## Tutorials & Helpful Resources 📚
+## Tutorials & helpful resources
 If you want to make maps with QGIS, this video is a great starting point. Check out also other videos by [Klas Karlson](https://www.youtube.com/playlist?list=PLNBeueOmuY163iwu4VpZdjqqdU1HkRTP_)
 - [Steven Bernard's QGIS Introduction](https://www.youtube.com/playlist?list=PL7HotvlLKHCs9nD1fFUjSOsZrsnctyV2R)
 - [QGIS Tutorials by Ujaval Gandhi](https://www.qgistutorials.com/en/)

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,8 +1,8 @@
 # Helpful resources
 
-## Data 🗺
+## Data
 
-You can use **what ever data you want.** But here are a few sources which could help you to get started or give you new ideas 👇
+You can use **whatever data you want.** Here are a few sources which could help you to get started or give you new ideas.
 
 - [OpenStreetMap](https://www.openstreetmap.org/)
 	- OpenStreetMap (OSM) is a collaborative project to create a free editable map of the world. If you seek for easy ways to get an extract of the data, you can check for [GeoFabrik](https://www.geofabrik.de/data/download.html) for Shapefiles  or [Overpass API for GeoJSONs etc.](https://overpass-turbo.eu/).
@@ -27,7 +27,7 @@ You can use **what ever data you want.** But here are a few sources which could 
 - [Data is Plural](https://www.data-is-plural.com/)
 	- The best data newsletter out there with an awesome archive including also some very obscure datasets. 
 
-## Tools 🔨🔧
+## Tools
 
 The challenge is open to any software, but here’s a list of popular open-source tools to consider. No programming skills are required. Or if you are a programmer, no design skills are required. 
 
@@ -55,7 +55,7 @@ The challenge is open to any software, but here’s a list of popular open-sourc
 	 - Reactive notebook environment for generation of visualization and cartographic output embedded in a textual narrative. Focus is on using [d3](https://d3js.org) for specifying visual output.
 	 
 
-## Tutorials & Helpful Resources 📚
+## Tutorials & helpful resources
 If you want to make maps with QGIS, this video is a great starting point. Check out also other videos by [Klas Karlson](https://www.youtube.com/playlist?list=PLNBeueOmuY163iwu4VpZdjqqdU1HkRTP_)
 - [Steven Bernard's QGIS Introduction](https://www.youtube.com/playlist?list=PL7HotvlLKHCs9nD1fFUjSOsZrsnctyV2R)
 - [QGIS Tutorials by Ujaval Gandhi](https://www.qgistutorials.com/en/)

--- a/docs/stylesheets/gbextra.css
+++ b/docs/stylesheets/gbextra.css
@@ -1,118 +1,325 @@
-/* Active tab bold & color */
-/*@import url("https://fonts.googleapis.com/css2?family=Oswald&display=swap");*/
-@import url("https://fontlibrary.org/face/trueno");
+/* ============================================================
+   #30DayMapChallenge — editorial cartographic theme
+   Palette: ink on paper, single terracotta accent.
+   ============================================================ */
 
-/* Cambia il carattere dei menu */
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&display=swap");
+
+/* ---------- Palette tokens ---------------------------------- */
+:root {
+  --site-paper:       #fafaf7;
+  --site-paper-soft:  #f3f2ec;
+  --site-rule:        #e5e3da;
+  --site-ink:         #1f2937;
+  --site-ink-soft:    #4b5563;
+  --site-accent:      #c2410c;
+  --site-accent-bg:   rgba(194, 65, 12, 0.08);
+}
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:             var(--site-ink);
+  --md-primary-fg-color--light:      #374151;
+  --md-primary-fg-color--dark:       #0f172a;
+  --md-primary-bg-color:             var(--site-paper);
+  --md-primary-bg-color--light:      var(--site-paper-soft);
+
+  --md-accent-fg-color:              var(--site-accent);
+  --md-accent-fg-color--transparent: var(--site-accent-bg);
+  --md-accent-bg-color:              #ffffff;
+
+  --md-default-bg-color:             var(--site-paper);
+  --md-default-fg-color--lightest:   var(--site-rule);
+
+  --md-typeset-a-color:              var(--site-accent);
+  --md-footer-bg-color:              var(--site-ink);
+  --md-footer-bg-color--dark:        #0f172a;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:             #14181f;
+  --md-default-fg-color:             #e7e6df;
+  --md-primary-fg-color:             #0f1318;
+  --md-primary-bg-color:             #e7e6df;
+  --md-accent-fg-color:              #fb923c;
+  --md-accent-fg-color--transparent: rgba(251, 146, 60, 0.18);
+  --md-typeset-a-color:              #fb923c;
+  --md-footer-bg-color:              #0f1318;
+}
+
+/* ---------- Typography -------------------------------------- */
 .md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4 {
+  font-family: "Fraunces", Georgia, "Times New Roman", serif;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--site-ink);
+}
+
+[data-md-color-scheme="slate"] .md-typeset h1,
+[data-md-color-scheme="slate"] .md-typeset h2,
+[data-md-color-scheme="slate"] .md-typeset h3,
+[data-md-color-scheme="slate"] .md-typeset h4 {
+  color: #f4f4ef;
+}
+
+.md-typeset h1 {
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0.8em 0 0.6em;
+  line-height: 1.15;
+}
+
+.md-typeset h2 {
+  font-size: 1.45rem;
+  margin-top: 2.2em;
+  padding-top: 0.6em;
+  border-top: 1px solid var(--site-rule);
+}
+
+.md-typeset h3 {
+  font-size: 1.1rem;
+}
+
+.md-typeset p,
+.md-typeset li {
+  line-height: 1.65;
+}
+
+/* Header, tabs and sidebar stay in sans */
+.md-header,
 .md-tabs,
-.md-header-nav__topic,
-.md-sidebar, 
-.md-ellipsis, 
-.md-source__icon+,
+.md-nav,
+.md-sidebar,
+.md-ellipsis,
 .md-source__repository {
-  font-family: "TruenoLight", /*Oswald,*/ sans-serif;
-  /* text-transform: uppercase!important;  */
- text-transform:  none!important; 
-  font-weight: bold;
-}
-
-.md-source__icon+,
-.md-source__repository {
-  font-family: "TruenoLight", /*Oswald,*/ sans-serif;
-  font-weight: bold;
-}
-
-.md-typeset h1, .md-tabs, .md-header-nav__topic, .md-sidebar, .md-ellipsis {
-    font-family: "TruenoLight", /*Oswald,*/ sans-serif;
-    /* text-transform: uppercase!important;  */
-    font-weight: bold;
-	text-align: left!important;
-}
-.md-typeset h1, .md-typeset h2 {
-    /*font-weight: 300;*/
-    letter-spacing: -.01em;
-	font-size: 1.5em;
+  font-family: var(--md-text-font-family, "Inter"), -apple-system,
+               BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .md-tabs__link {
-    font-size: .75rem !important;
+  font-size: 0.78rem !important;
+  font-weight: 500;
+  opacity: 0.9;
+  text-transform: none !important;
 }
 .md-tabs__link--active {
-    font-weight: bold !important;
-    color: var(--md-accent-fg-color);
+  font-weight: 700 !important;
+  opacity: 1;
 }
 .md-tabs__link:hover {
-    color: var(--md-accent-fg-color);
+  color: var(--md-accent-fg-color);
 }
 
-
-/* navigation bar active color*/
-.md-nav__item .md-nav__link--active {
-    font-weight: bold !important;
-    color: var(--md-accent-fg-color);
+.md-nav__link {
+  font-size: 0.78rem;
 }
 .md-nav__item .md-nav__link--active {
-    font-weight: bold !important;
-    font-size: .75rem !important;
-    color: var(--md-accent-fg-color);
+  font-weight: 600;
+  color: var(--md-accent-fg-color);
 }
 
-/* frontpage elements */
-.tx-hero h1 {
-    font-size: 2.41rem !important;
+/* ---------- Tables ------------------------------------------ */
+.md-typeset table:not([class]) {
+  border: none;
+  box-shadow: none;
+  font-size: 0.78rem;
+  display: table;
+  width: 100%;
+  background: transparent;
+}
+
+.md-typeset table:not([class]) th {
+  background: var(--site-paper-soft) !important;
+  color: var(--site-ink) !important;
+  font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7rem;
+  border-top: 2px solid var(--site-ink) !important;
+  border-bottom: 2px solid var(--site-ink) !important;
+  padding: 0.75em 1em;
+  text-align: left;
+}
+
+.md-typeset table:not([class]) td {
+  border-top: 1px solid var(--site-rule);
+  padding: 0.6em 1em;
+  vertical-align: top;
+  background: transparent;
+}
+
+.md-typeset table:not([class]) tr {
+  background: transparent;
+}
+
+.md-typeset table:not([class]) tbody tr:hover td {
+  background: var(--site-paper-soft);
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background: #1f242c !important;
+  color: #f4f4ef !important;
+  border-color: #f4f4ef !important;
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) td {
+  border-color: #262b34;
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tbody tr:hover td {
+  background: #1a1f27;
+}
+
+/* ---------- Buttons ----------------------------------------- */
+a.md-button {
+  border: 1px solid var(--site-ink);
+  border-radius: 2px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  transition: background-color 150ms ease, color 150ms ease,
+              border-color 150ms ease;
 }
 a.md-button.md-button--primary {
-    background-color: var(--md-accent-fg-color);
-    border-color: var(--md-accent-fg-color);
-    color: #ffffff;
+  background-color: var(--site-ink);
+  border-color: var(--site-ink);
+  color: var(--site-paper);
 }
-a.md-button.md-button--primary:hover {
-    color: #000000;
-}
-a.md-button.md-button:hover {
-    color: #000000;
+a.md-button.md-button--primary:hover,
+a.md-button:hover {
+  background-color: var(--site-accent);
+  border-color: var(--site-accent);
+  color: #ffffff;
 }
 
+/* ---------- Images ------------------------------------------ */
+.md-typeset img {
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  padding: 0;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08),
+              0 4px 12px rgba(15, 23, 42, 0.06);
+  max-width: 100%;
+  height: auto;
+}
 
-/*Table styling*/
-table {
-  padding: 0; }
-  table tr {
-    border-top: 1px solid #cccccc;
-    background-color: white;
-    margin: 0;
-    padding: 0; }
-    table tr:nth-child(2n) {
-      background-color: #f8f8f8; }
-    table tr th {
-      font-weight: bold;
-      border: 0px solid #cccccc;
-      text-align: centre;
-      margin: 0;
-      padding: 6px 13px; }
-    table tr td {
-      border: 0px solid #cccccc;
-      text-align: centre;
-      margin: 0;
-      padding: 6px 13px; }
-    table tr th :first-child, table tr td :first-child {
-      margin-top: 0; }
-    table tr th :last-child, table tr td :last-child {
-      margin-bottom: 0; }
-	  
-/*Intestazione tabella*/	  
-.md-typeset table:not([class]) th {
-    background-color: rgb(240 230 74 / 75%)!important; 
-    color: rgb(0 0 0 / 87%)!important; }
-/* gbvitrano*/
-/*Tabbed extension css*/
+[data-md-color-scheme="slate"] .md-typeset img {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4),
+              0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* Bare images — logos, transparent decorative SVGs */
+.md-typeset .immagonobox,
+.immagonobox,
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg,
+.md-nav__title .md-nav__button.md-logo img,
+.md-nav__title .md-nav__button.md-logo svg {
+  border: none !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  padding: 0 !important;
+}
+
+/* Logo sizing */
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg {
+  height: 2.4rem !important;
+  width: auto !important;
+  max-width: 14rem;
+  padding-right: 1.5rem !important;
+}
+
+.md-nav__title .md-nav__button.md-logo img,
+.md-nav__title .md-nav__button.md-logo svg {
+  fill: currentColor;
+  display: block;
+  height: 2.4rem !important;
+  width: auto !important;
+  padding-right: 1rem !important;
+}
+
+/* ---------- Admonitions ------------------------------------- */
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 4px;
+  border-left-width: 3px;
+  font-size: 0.78rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+}
+
+.md-typeset .admonition.info,
+.md-typeset details.info,
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-left-color: var(--site-accent);
+}
+.md-typeset .admonition.info > .admonition-title,
+.md-typeset details.info > summary,
+.md-typeset .admonition.tip > .admonition-title,
+.md-typeset details.tip > summary {
+  background-color: var(--site-accent-bg);
+}
+.md-typeset .admonition.info > .admonition-title::before,
+.md-typeset details.info > summary::before,
+.md-typeset .admonition.tip > .admonition-title::before,
+.md-typeset details.tip > summary::before {
+  background-color: var(--site-accent);
+}
+
+/* ---------- Site width -------------------------------------- */
+.md-grid {
+  max-width: 64rem !important;
+}
+
+/* ---------- Horizontal rules -------------------------------- */
+.md-typeset hr,
+.hr-hfc,
+.hr {
+  border: 0;
+  height: 1px;
+  background: var(--site-rule);
+  background-image: none;
+  margin: 2em 0;
+}
+
+/* ---------- Footer ------------------------------------------ */
+.md-footer__link {
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+}
+
+/* ---------- Scrollbar --------------------------------------- */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(31, 41, 55, 0.25);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(31, 41, 55, 0.45);
+}
+
+[data-md-color-scheme="slate"] ::-webkit-scrollbar-thumb {
+  background: rgba(244, 244, 239, 0.2);
+}
+
+/* ---------- Tabbed extension -------------------------------- */
 .tabbed-set {
   display: flex;
   position: relative;
   flex-wrap: wrap;
 }
 .tabbed-set .highlight {
-  background: #ddd;
+  background: var(--site-paper-soft);
 }
 .tabbed-set .tabbed-content {
   display: none;
@@ -121,163 +328,83 @@ table {
 }
 .tabbed-set label {
   width: auto;
-  margin: 0 0.5em;
-  padding: 0.25em;
-  font-size: 120%;
+  margin: 0 0.75em 0 0;
+  padding: 0.25em 0.5em;
+  font-size: 0.9rem;
+  font-weight: 500;
   cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: var(--site-ink-soft);
 }
 .tabbed-set input {
   position: absolute;
   opacity: 0;
 }
-.tabbed-set input:nth-child(n+1) {
-  color: #333333;
-}
 .tabbed-set input:nth-child(n+1):checked + label {
-    color: #FF5252;
+  color: var(--site-accent);
+  border-bottom-color: var(--site-accent);
 }
 .tabbed-set input:nth-child(n+1):checked + label + .tabbed-content {
-    display: block;
+  display: block;
 }
 
-
-/* Admonition settings option*/
-.md-typeset .admonition.settings, .md-typeset details.settings {
-    border-left: .22rem solid #448aff;
-}
-.md-typeset .admonition.settings>.admonition-title, .md-typeset details.settings>.admonition-title, .md-typeset details.settings>summary {
-    border-bottom: .1rem solid rgba(236, 243, 255, 0.1);
-    background-color: rgba(236, 243, 255, 0.1);
-}
-.md-typeset .admonition.settings>.admonition-title:before, .md-typeset details.settings>.admonition-title:before, .md-typeset details.settings>summary:before {
-    color: #448aff;
-    content: "settings"}
-
-
-/* Site width etc.*/
-.md-grid {
-    /*max-width: 64rem !important;*/
-	max-width: 100% !important;
-}
-
-
-/* mkdocstrings styling
-/* Indentation. */
-div.doc-contents:not(.first) {
-  padding-left: 25px;
-  border-left: 4px solid rgba(230, 230, 230);
-  margin-bottom: 80px;
-}
-
-
-/* logo personalizzato*/
-.md-header__button.md-logo img, .md-header__button.md-logo svg {height: 2.5rem!important;    width: 12rem!important; padding-right: 3rem!important; box-shadow: none !important; border: none !important;	border-radius:  none !important;	moz-border-radius: none !important; -webkit-border-radius: none !important;	background-color: transparent !important;}
-
-/* logo personalizzato mobile*/
-.md-nav__title .md-nav__button.md-logo img, .md-nav__title .md-nav__button.md-logo svg {fill: currentColor; display: block; height: 2.5rem!important; width: 12rem !important;padding-right: 3rem; box-shadow: none !important;  border: none !important; border-radius: none !important; moz-border-radius: none !important; -webkit-border-radius: none !important;   background-color: transparent !important;}
-
-/*mod. colore primario deep orange*/
-[data-md-color-primary=deep-orange] {--md-primary-fg-color: #f18d36!important; --md-primary-fg-color--dark: #f18d36!important;}
-
-/*mod. colore accent green*/	
-[data-md-color-accent=green] { --md-accent-fg-color: #589632!important; }
-
-/*mod. colore footer prev/next*/
-/*:root>* {--md-footer-bg-color: rgb(241 141 54 / 100%)!important; }*/
-
-/*mod. altezza footer prev/next*/
-.md-footer__link {padding-bottom: .1rem!important; padding-top: .4rem!important; }
-
-/* Hide back to top button on mobile devices */
-@media screen and (max-width: 76.1875em) {
-  .md-top {
-    display: none !important;
-  }
-}
-
-/*base icona home*/
-.svg-inline--fa.fa-stack-2x { width: 1em!important;}
-
-/*menu mobile home home*/
-@media screen and (max-width: 76.1875em) {
-.md-nav--primary .md-nav__title~.md-nav__list {
-    background-color: var(--md-default-bg-color);
-    box-shadow: 0 .05rem 0 var(--md-default-fg-color--lightest) inset;
-    overflow-y: auto;
-    -ms-scroll-snap-type: y mandatory;
-    scroll-snap-type: y mandatory;
-    touch-action: pan-y;
-    text-align: left!important;
-}
-	.md-nav__list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    text-align: left!important;
-}
-}
-/* Sfondo QGIS
-.md-main { background-image:url(../imgs/qsfondo_800.png)!important; background-repeat: no-repeat!important;  background-position: center center!important; background-size: 90%!important;  background-attachment: fixed !important;  -webkit-backface-visibility: hidden !important; background:  #efefef;}*/
-	
-/* bordo immagine*/
-img {box-shadow: 0 1px 2.5px rgba(0,0,0,0.65);	border-radius: 5px;	moz-border-radius: 5px; -webkit-border-radius: 5px;	border: 1px solid #589632;	padding: 1px;background-color: #fff;}
-	
-/* immagine no bordo/ no ombra */
-.immagonobox {	max-width: 100%!important;    height: auto!important;	box-shadow: none !important; border: none !important;	border-radius:  none !important;	moz-border-radius: none !important; -webkit-border-radius: none !important;	background-color: transparent !important;	}		
-
- /*sposta più in alto il back to top in mobile se è installata la condivisione social; */
- @media screen and (max-width: 1100px) { .md-top {bottom: 2.5rem!important;}}
-
-.hr-hfc {border: 0; height: 1px; background:  #589632; background-image: linear-gradient(to right, #93b023,  #589632, #93b023);  width: 100%; margin: 20px 0;}	
-	
-  /*Clip resize; */
-.clip_resize {height: 100% /*width: 100%;  border-radius: 5px;  -moz-border-radius: 5px;  -webkit-border-radius: 5px;border: 1px solid #ccc;background-color:#fff; padding:1px; box-shadow: 0 2px 5px rgba(0,0,0,0.2) */} 
-
-.rst-versions.rst-badge .rst-current-version {display: none!important; }
-
-
-/* icona social */
+/* ---------- Social icons ------------------------------------ */
 .social-icons .social-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   height: 1.75rem;
   width: 1.75rem;
-  background-color: #5896329e;
-  color: #fff;
+  background-color: var(--site-ink);
+  color: var(--site-paper);
   border-radius: 100%;
   font-size: 1.1rem;
-  margin-right: 0.3rem;}
-
-.social-icons .social-icon:last-child {
-  margin-right: 0;}
-
-.social-icons .social-icon:hover {
-  background-color: #f18d36;}
-  
- /* scrollbar*/
-
-::-webkit-scrollbar {
-    width: 7px;
-	height:7px;
+  margin-right: 0.3rem;
+  transition: background-color 150ms ease;
 }
- 
-::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 10px rgba(255,255,255,0.9); 
-    border-radius: 0px;
+.social-icons .social-icon:last-child { margin-right: 0; }
+.social-icons .social-icon:hover { background-color: var(--site-accent); }
+
+/* ---------- Front page hero --------------------------------- */
+.tx-hero h1 {
+  font-size: 2.6rem !important;
+  font-family: "Fraunces", Georgia, serif;
+  letter-spacing: -0.02em;
 }
- 
-::-webkit-scrollbar-thumb:vertical {
-height: 50px;
-background-color: rgba(0,0,0,0.2);
-border: 1px solid rgba(0,0,0,0.2);
--webkit-border-radius: 6px;
-max-height:100px;
-}  
- 
- 
-/* rettangolo info stampa pdf */  
-#print-site-banner {border-color: #ff0000!important; border-radius: 10px!important; }
-	
- /*no pubblicità */
- [data-ea-publisher].loaded, [data-ea-type].loaded {display: none!important; }	
+
+/* ---------- Responsive tweaks ------------------------------- */
+@media screen and (max-width: 76.1875em) {
+  .md-top { display: none !important; }
+  .md-nav--primary .md-nav__title ~ .md-nav__list {
+    background-color: var(--md-default-bg-color);
+    box-shadow: 0 0.05rem 0 var(--md-default-fg-color--lightest) inset;
+    overflow-y: auto;
+    scroll-snap-type: y mandatory;
+    touch-action: pan-y;
+    text-align: left !important;
+  }
+  .md-nav__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    text-align: left !important;
+  }
+}
+@media screen and (max-width: 1100px) {
+  .md-top { bottom: 2.5rem !important; }
+}
+
+/* ---------- Print / misc ------------------------------------ */
+#print-site-banner {
+  border-color: var(--site-accent) !important;
+  border-radius: 4px !important;
+}
+
+[data-ea-publisher].loaded,
+[data-ea-type].loaded {
+  display: none !important;
+}
+
+.rst-versions.rst-badge .rst-current-version {
+  display: none !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,16 +26,31 @@ theme:
   features:
     - navigation.top
     - navigation.tabs
+    - navigation.tracking
+    - navigation.instant
+    - content.tabs.link
     - search.suggest
     - search.share
+    - toc.follow
   back-to-top: false
   palette:
-    - scheme: default
-      primary: deep blue
-      accent: deep orange
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   font:
-    text: Lato
-    code: Roboto Mono
+    text: Inter
+    code: JetBrains Mono
   favicon: imgs/favicon.ico
   logo: imgs/30DMC_logo.svg
   icon:


### PR DESCRIPTION
Replace the deep-blue + yellow-table palette with an ink-on-paper
look: near-black primary, single terracotta accent, off-white
background, Fraunces serif headings paired with Inter for UI/body.
Add a light/dark palette toggle, remove the unreliable TruenoLight
font import, and strip emojis from headings for a more polished
cartography/design feel.