### PR TITLE
Add countdown to next #30DayMapChallenge on home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,26 @@
 ## Daily social mapping project happening every November
 
 <div id="challenge-countdown" class="challenge-countdown" hidden aria-live="polite">
-  <div class="challenge-countdown__label">Next challenge starts in</div>
-  <div class="challenge-countdown__grid">
-    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-days>--</span><span class="challenge-countdown__unit">days</span></div>
-    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-hours>--</span><span class="challenge-countdown__unit">hours</span></div>
-    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-minutes>--</span><span class="challenge-countdown__unit">minutes</span></div>
-    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-seconds>--</span><span class="challenge-countdown__unit">seconds</span></div>
+  <div class="challenge-countdown__block" data-cd-block="themes">
+    <div class="challenge-countdown__label" data-cd-label>Themes announced in</div>
+    <div class="challenge-countdown__grid" data-cd-grid>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-days>--</span><span class="challenge-countdown__unit">days</span></div>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-hours>--</span><span class="challenge-countdown__unit">hours</span></div>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-minutes>--</span><span class="challenge-countdown__unit">minutes</span></div>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-seconds>--</span><span class="challenge-countdown__unit">seconds</span></div>
+    </div>
+    <div class="challenge-countdown__target" data-cd-target></div>
   </div>
-  <div class="challenge-countdown__target" data-cd-target></div>
+  <div class="challenge-countdown__block" data-cd-block="challenge">
+    <div class="challenge-countdown__label" data-cd-label>Challenge starts in</div>
+    <div class="challenge-countdown__grid" data-cd-grid>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-days>--</span><span class="challenge-countdown__unit">days</span></div>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-hours>--</span><span class="challenge-countdown__unit">hours</span></div>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-minutes>--</span><span class="challenge-countdown__unit">minutes</span></div>
+      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-seconds>--</span><span class="challenge-countdown__unit">seconds</span></div>
+    </div>
+    <div class="challenge-countdown__target" data-cd-target></div>
+  </div>
 </div>
 
 The official repository for #30DayMapChallenge, a daily mapping challenge open to everyone.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,16 @@
 ## Daily social mapping project happening every November
 
+<div id="challenge-countdown" class="challenge-countdown" hidden aria-live="polite">
+  <div class="challenge-countdown__label">Next challenge starts in</div>
+  <div class="challenge-countdown__grid">
+    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-days>--</span><span class="challenge-countdown__unit">days</span></div>
+    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-hours>--</span><span class="challenge-countdown__unit">hours</span></div>
+    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-minutes>--</span><span class="challenge-countdown__unit">minutes</span></div>
+    <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-seconds>--</span><span class="challenge-countdown__unit">seconds</span></div>
+  </div>
+  <div class="challenge-countdown__target" data-cd-target></div>
+</div>
+
 The official repository for #30DayMapChallenge, a daily mapping challenge open to everyone.
 
 The challenge takes place every November, with 30 different mapping themes - one for each day of the month. Participants create maps based on these themes and share them on social media using the hashtag `#30DayMapChallenge`.

--- a/docs/stylesheets/extra.js
+++ b/docs/stylesheets/extra.js
@@ -6,3 +6,96 @@ for (var i = 0, linksLength = links.length; i < linksLength; i++) {
        links[i].target = '_blank';
    }
 }
+
+// Countdown to the next #30DayMapChallenge (every November).
+(function () {
+  var timerId = null;
+
+  function nextChallengeWindow(now) {
+    var year = now.getFullYear();
+    var start = new Date(year, 10, 1, 0, 0, 0, 0);   // 1 November, local time
+    var end   = new Date(year, 11, 1, 0, 0, 0, 0);   // 1 December, local time
+    if (now >= end) {
+      start = new Date(year + 1, 10, 1, 0, 0, 0, 0);
+      end   = new Date(year + 1, 11, 1, 0, 0, 0, 0);
+    }
+    return { start: start, end: end, live: now >= start && now < end };
+  }
+
+  function formatDate(d) {
+    try {
+      return d.toLocaleDateString(undefined, {
+        year: "numeric", month: "long", day: "numeric"
+      });
+    } catch (e) {
+      return d.toDateString();
+    }
+  }
+
+  function render(root) {
+    var now = new Date();
+    var win = nextChallengeWindow(now);
+    var target = win.live ? win.end : win.start;
+    var diff = Math.max(0, target - now);
+
+    var totalSeconds = Math.floor(diff / 1000);
+    var days = Math.floor(totalSeconds / 86400);
+    var hours = Math.floor((totalSeconds % 86400) / 3600);
+    var minutes = Math.floor((totalSeconds % 3600) / 60);
+    var seconds = totalSeconds % 60;
+
+    var label = root.querySelector(".challenge-countdown__label");
+    var note  = root.querySelector("[data-cd-target]");
+    var d = root.querySelector("[data-cd-days]");
+    var h = root.querySelector("[data-cd-hours]");
+    var m = root.querySelector("[data-cd-minutes]");
+    var s = root.querySelector("[data-cd-seconds]");
+
+    if (win.live) {
+      root.classList.add("challenge-countdown--live");
+      if (label) label.textContent = "The #30DayMapChallenge is live!";
+      if (d) d.parentElement.style.display = "none";
+      if (h) h.parentElement.style.display = "none";
+      if (m) m.parentElement.style.display = "none";
+      if (s) {
+        s.parentElement.style.display = "";
+        s.textContent = "Day " + (Math.floor((now - win.start) / 86400000) + 1) + " of 30";
+        var unit = s.parentElement.querySelector(".challenge-countdown__unit");
+        if (unit) unit.textContent = "happening now";
+      }
+      if (note) note.textContent = "Share your maps with #30DayMapChallenge through " + formatDate(new Date(win.end - 1));
+    } else {
+      root.classList.remove("challenge-countdown--live");
+      if (label) label.textContent = "Next challenge starts in";
+      if (d) d.textContent = days;
+      if (h) h.textContent = String(hours).padStart(2, "0");
+      if (m) m.textContent = String(minutes).padStart(2, "0");
+      if (s) s.textContent = String(seconds).padStart(2, "0");
+      if (note) note.textContent = "Kicks off " + formatDate(win.start);
+    }
+    root.hidden = false;
+  }
+
+  function setup() {
+    if (timerId) { clearInterval(timerId); timerId = null; }
+    var root = document.getElementById("challenge-countdown");
+    if (!root) return;
+    render(root);
+    timerId = setInterval(function () {
+      var el = document.getElementById("challenge-countdown");
+      if (!el) { clearInterval(timerId); timerId = null; return; }
+      render(el);
+    }, 1000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setup);
+  } else {
+    setup();
+  }
+
+  // Material for MkDocs instant navigation: re-run on each page swap.
+  if (typeof window.document$ !== "undefined" && window.document$.subscribe) {
+    window.document$.subscribe(setup);
+  }
+})();

--- a/docs/stylesheets/extra.js
+++ b/docs/stylesheets/extra.js
@@ -7,19 +7,23 @@ for (var i = 0, linksLength = links.length; i < linksLength; i++) {
    }
 }
 
-// Countdown to the next #30DayMapChallenge (every November).
+// Countdown to the next #30DayMapChallenge.
+// Two milestones: 1 October (themes announced) and 1 November (challenge starts).
 (function () {
   var timerId = null;
 
-  function nextChallengeWindow(now) {
+  function milestonesFor(now) {
     var year = now.getFullYear();
-    var start = new Date(year, 10, 1, 0, 0, 0, 0);   // 1 November, local time
-    var end   = new Date(year, 11, 1, 0, 0, 0, 0);   // 1 December, local time
+    var themes    = new Date(year, 9, 1, 0, 0, 0, 0);   // 1 October
+    var challenge = new Date(year, 10, 1, 0, 0, 0, 0);  // 1 November
+    var end       = new Date(year, 11, 1, 0, 0, 0, 0);  // 1 December
     if (now >= end) {
-      start = new Date(year + 1, 10, 1, 0, 0, 0, 0);
-      end   = new Date(year + 1, 11, 1, 0, 0, 0, 0);
+      year += 1;
+      themes    = new Date(year, 9, 1, 0, 0, 0, 0);
+      challenge = new Date(year, 10, 1, 0, 0, 0, 0);
+      end       = new Date(year, 11, 1, 0, 0, 0, 0);
     }
-    return { start: start, end: end, live: now >= start && now < end };
+    return { year: year, themes: themes, challenge: challenge, end: end };
   }
 
   function formatDate(d) {
@@ -32,47 +36,77 @@ for (var i = 0, linksLength = links.length; i < linksLength; i++) {
     }
   }
 
+  function pad(n) { return String(n).padStart(2, "0"); }
+
+  function renderCountdown(block, target) {
+    var now = new Date();
+    var diff = Math.max(0, target - now);
+    var total = Math.floor(diff / 1000);
+    var days = Math.floor(total / 86400);
+    var hours = Math.floor((total % 86400) / 3600);
+    var minutes = Math.floor((total % 3600) / 60);
+    var seconds = total % 60;
+
+    block.classList.remove("challenge-countdown__block--done", "challenge-countdown__block--banner");
+    var grid = block.querySelector("[data-cd-grid]");
+    if (grid) {
+      grid.innerHTML =
+        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + days + '</span><span class="challenge-countdown__unit">days</span></div>' +
+        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(hours) + '</span><span class="challenge-countdown__unit">hours</span></div>' +
+        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(minutes) + '</span><span class="challenge-countdown__unit">minutes</span></div>' +
+        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(seconds) + '</span><span class="challenge-countdown__unit">seconds</span></div>';
+    }
+  }
+
+  function renderBanner(block, text) {
+    block.classList.add("challenge-countdown__block--banner");
+    var grid = block.querySelector("[data-cd-grid]");
+    if (grid) {
+      grid.innerHTML = '<span class="challenge-countdown__value">' + text + '</span>';
+    }
+  }
+
+  function setLabel(block, text) {
+    var el = block.querySelector("[data-cd-label]");
+    if (el) el.textContent = text;
+  }
+
+  function setNote(block, text) {
+    var el = block.querySelector("[data-cd-target]");
+    if (el) el.textContent = text;
+  }
+
   function render(root) {
     var now = new Date();
-    var win = nextChallengeWindow(now);
-    var target = win.live ? win.end : win.start;
-    var diff = Math.max(0, target - now);
+    var m = milestonesFor(now);
+    var themesBlock = root.querySelector('[data-cd-block="themes"]');
+    var challengeBlock = root.querySelector('[data-cd-block="challenge"]');
+    if (!themesBlock || !challengeBlock) return;
 
-    var totalSeconds = Math.floor(diff / 1000);
-    var days = Math.floor(totalSeconds / 86400);
-    var hours = Math.floor((totalSeconds % 86400) / 3600);
-    var minutes = Math.floor((totalSeconds % 3600) / 60);
-    var seconds = totalSeconds % 60;
-
-    var label = root.querySelector(".challenge-countdown__label");
-    var note  = root.querySelector("[data-cd-target]");
-    var d = root.querySelector("[data-cd-days]");
-    var h = root.querySelector("[data-cd-hours]");
-    var m = root.querySelector("[data-cd-minutes]");
-    var s = root.querySelector("[data-cd-seconds]");
-
-    if (win.live) {
-      root.classList.add("challenge-countdown--live");
-      if (label) label.textContent = "The #30DayMapChallenge is live!";
-      if (d) d.parentElement.style.display = "none";
-      if (h) h.parentElement.style.display = "none";
-      if (m) m.parentElement.style.display = "none";
-      if (s) {
-        s.parentElement.style.display = "";
-        s.textContent = "Day " + (Math.floor((now - win.start) / 86400000) + 1) + " of 30";
-        var unit = s.parentElement.querySelector(".challenge-countdown__unit");
-        if (unit) unit.textContent = "happening now";
-      }
-      if (note) note.textContent = "Share your maps with #30DayMapChallenge through " + formatDate(new Date(win.end - 1));
+    // Themes block
+    if (now < m.themes) {
+      setLabel(themesBlock, "Themes announced in");
+      renderCountdown(themesBlock, m.themes);
+      setNote(themesBlock, formatDate(m.themes));
     } else {
-      root.classList.remove("challenge-countdown--live");
-      if (label) label.textContent = "Next challenge starts in";
-      if (d) d.textContent = days;
-      if (h) h.textContent = String(hours).padStart(2, "0");
-      if (m) m.textContent = String(minutes).padStart(2, "0");
-      if (s) s.textContent = String(seconds).padStart(2, "0");
-      if (note) note.textContent = "Kicks off " + formatDate(win.start);
+      themesBlock.classList.add("challenge-countdown__block--done");
+      setLabel(themesBlock, "Themes for " + m.year);
+      renderBanner(themesBlock, "Now available");
+      setNote(themesBlock, "Released " + formatDate(m.themes));
     }
+
+    // Challenge block
+    if (now < m.challenge) {
+      setLabel(challengeBlock, "Challenge starts in");
+      renderCountdown(challengeBlock, m.challenge);
+      setNote(challengeBlock, formatDate(m.challenge));
+    } else if (now < m.end) {
+      var day = Math.floor((now - m.challenge) / 86400000) + 1;
+      setLabel(challengeBlock, "#30DayMapChallenge is live");
+      renderBanner(challengeBlock, "Day " + day + " of 30");
+      setNote(challengeBlock, "Runs through " + formatDate(new Date(m.end - 1)));
+    }
+
     root.hidden = false;
   }
 

--- a/docs/stylesheets/gbextra.css
+++ b/docs/stylesheets/gbextra.css
@@ -372,6 +372,110 @@ a.md-button:hover {
   letter-spacing: -0.02em;
 }
 
+/* ---------- Countdown --------------------------------------- */
+.challenge-countdown {
+  margin: 1.4em 0 2em;
+  padding: 1.1em 1.25em 1em;
+  border: 1px solid var(--site-rule);
+  border-left: 3px solid var(--site-accent);
+  border-radius: 4px;
+  background: var(--site-paper-soft);
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown {
+  background: #1a1f27;
+  border-color: #262b34;
+  border-left-color: var(--md-accent-fg-color);
+}
+
+.challenge-countdown__label {
+  font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--site-ink-soft);
+  margin-bottom: 0.6em;
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown__label {
+  color: #b8b7b0;
+}
+
+.challenge-countdown__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5em;
+}
+
+.challenge-countdown__cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5em 0.25em;
+  background: var(--site-paper);
+  border-radius: 3px;
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown__cell {
+  background: #14181f;
+}
+
+.challenge-countdown__value {
+  font-family: "Fraunces", Georgia, serif;
+  font-size: 1.9rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  color: var(--site-ink);
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown__value {
+  color: #f4f4ef;
+}
+
+.challenge-countdown__unit {
+  font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--site-ink-soft);
+  margin-top: 0.25em;
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown__unit {
+  color: #b8b7b0;
+}
+
+.challenge-countdown__target {
+  margin-top: 0.7em;
+  font-size: 0.72rem;
+  color: var(--site-ink-soft);
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown__target {
+  color: #b8b7b0;
+}
+
+.challenge-countdown--live .challenge-countdown__grid {
+  grid-template-columns: 1fr;
+}
+
+.challenge-countdown--live .challenge-countdown__value {
+  font-size: 1.5rem;
+  color: var(--site-accent);
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown--live .challenge-countdown__value {
+  color: var(--md-accent-fg-color);
+}
+
+@media screen and (max-width: 30em) {
+  .challenge-countdown__value { font-size: 1.5rem; }
+}
+
 /* ---------- Responsive tweaks ------------------------------- */
 @media screen and (max-width: 76.1875em) {
   .md-top { display: none !important; }

--- a/docs/stylesheets/gbextra.css
+++ b/docs/stylesheets/gbextra.css
@@ -374,18 +374,35 @@ a.md-button:hover {
 
 /* ---------- Countdown --------------------------------------- */
 .challenge-countdown {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.9em;
   margin: 1.4em 0 2em;
-  padding: 1.1em 1.25em 1em;
+}
+
+.challenge-countdown__block {
+  padding: 1.1em 1.1em 1em;
   border: 1px solid var(--site-rule);
   border-left: 3px solid var(--site-accent);
   border-radius: 4px;
   background: var(--site-paper-soft);
+  display: flex;
+  flex-direction: column;
 }
 
-[data-md-color-scheme="slate"] .challenge-countdown {
+[data-md-color-scheme="slate"] .challenge-countdown__block {
   background: #1a1f27;
   border-color: #262b34;
   border-left-color: var(--md-accent-fg-color);
+}
+
+.challenge-countdown__block--done {
+  border-left-color: var(--site-rule);
+  opacity: 0.78;
+}
+
+[data-md-color-scheme="slate"] .challenge-countdown__block--done {
+  border-left-color: #262b34;
 }
 
 .challenge-countdown__label {
@@ -395,7 +412,7 @@ a.md-button:hover {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--site-ink-soft);
-  margin-bottom: 0.6em;
+  margin-bottom: 0.7em;
 }
 
 [data-md-color-scheme="slate"] .challenge-countdown__label {
@@ -405,7 +422,7 @@ a.md-button:hover {
 .challenge-countdown__grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.5em;
+  gap: 0.4em;
 }
 
 .challenge-countdown__cell {
@@ -413,7 +430,7 @@ a.md-button:hover {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 0.5em 0.25em;
+  padding: 0.55em 0.2em;
   background: var(--site-paper);
   border-radius: 3px;
 }
@@ -424,7 +441,7 @@ a.md-button:hover {
 
 .challenge-countdown__value {
   font-family: "Fraunces", Georgia, serif;
-  font-size: 1.9rem;
+  font-size: 1.55rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
@@ -437,7 +454,7 @@ a.md-button:hover {
 
 .challenge-countdown__unit {
   font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
-  font-size: 0.65rem;
+  font-size: 0.6rem;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -450,7 +467,8 @@ a.md-button:hover {
 }
 
 .challenge-countdown__target {
-  margin-top: 0.7em;
+  margin-top: auto;
+  padding-top: 0.7em;
   font-size: 0.72rem;
   color: var(--site-ink-soft);
 }
@@ -459,21 +477,37 @@ a.md-button:hover {
   color: #b8b7b0;
 }
 
-.challenge-countdown--live .challenge-countdown__grid {
-  grid-template-columns: 1fr;
+/* Banner state (themes-out announcement or live challenge) */
+.challenge-countdown__block--banner .challenge-countdown__grid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 4.2rem;
+  padding: 0.4em 0.6em;
+  background: var(--site-paper);
+  border-radius: 3px;
 }
 
-.challenge-countdown--live .challenge-countdown__value {
-  font-size: 1.5rem;
+[data-md-color-scheme="slate"] .challenge-countdown__block--banner .challenge-countdown__grid {
+  background: #14181f;
+}
+
+.challenge-countdown__block--banner .challenge-countdown__value {
+  font-size: 1.15rem;
   color: var(--site-accent);
+  text-align: center;
+  line-height: 1.3;
 }
 
-[data-md-color-scheme="slate"] .challenge-countdown--live .challenge-countdown__value {
+[data-md-color-scheme="slate"] .challenge-countdown__block--banner .challenge-countdown__value {
   color: var(--md-accent-fg-color);
 }
 
-@media screen and (max-width: 30em) {
-  .challenge-countdown__value { font-size: 1.5rem; }
+@media screen and (max-width: 48em) {
+  .challenge-countdown {
+    grid-template-columns: 1fr;
+  }
+  .challenge-countdown__value { font-size: 1.4rem; }
 }
 
 /* ---------- Responsive tweaks ------------------------------- */


### PR DESCRIPTION
Counts down in days/hours/minutes/seconds to 1 November in the user's
local time. During November it switches to a live-now state showing
which day of 30 the challenge is on, then rolls over to the next year.