### PR TITLE
Add Google Analytics 4 with cookie consent banner

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -30,4 +30,6 @@ jobs:
       
       # Deploy the site using mkdocs
       - name: Deploy with MkDocs
+        env:
+          GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
         run: mkdocs gh-deploy --force

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -30,6 +30,4 @@ jobs:
       
       # Deploy the site using mkdocs
       - name: Deploy with MkDocs
-        env:
-          GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
         run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,9 +17,7 @@ extra:
       link: https://github.com/tjukanovt/30DayMapChallenge
   analytics:
     provider: google
-    # ID is supplied via the GOOGLE_ANALYTICS_KEY env var so it stays out of the
-    # repo and only fires on builds where it is set (e.g. the production deploy).
-    property: !ENV [GOOGLE_ANALYTICS_KEY, ""]
+    property: G-Z3RZNVKSNS
   consent:
     title: Cookie consent
     description: >-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,24 @@ extra:
   social:
     - icon: fontawesome/solid/house
       link: https://github.com/tjukanovt/30DayMapChallenge
+  analytics:
+    provider: google
+    # ID is supplied via the GOOGLE_ANALYTICS_KEY env var so it stays out of the
+    # repo and only fires on builds where it is set (e.g. the production deploy).
+    property: !ENV [GOOGLE_ANALYTICS_KEY, ""]
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to measure how visitors use the site so we can make it
+      better. With your consent you help us understand what is most useful.
+    cookies:
+      analytics:
+        name: Google Analytics
+        checked: false
+    actions:
+      - accept
+      - reject
+      - manage
 
 # Configuration
 theme:


### PR DESCRIPTION
## Summary

Enables visitor analytics on the site using Material for MkDocs' built-in Google Analytics 4 integration, with a cookie consent banner.

- **GA4 tracking** via `extra.analytics` (provider `google`, property `G-Z3RZNVKSNS`). Material injects the `gtag.js` snippet on every page and auto-tracks page views across the theme's instant-navigation page swaps.
- **Cookie consent banner** via `extra.consent` with an Analytics toggle that's unchecked by default, so GA cookies only load after a visitor opts in (helps with GDPR/ePrivacy for the global audience).

The GA4 Measurement ID is a public, client-side identifier (exposed in the live site's HTML), so it's set directly in `mkdocs.yml` rather than via a secret — no repo secrets or workflow changes are needed.

## Test plan

- [x] `mkdocs build --strict` passes (the check CI runs)
- [x] Built HTML embeds `gtag/js?id=G-Z3RZNVKSNS`
- [x] Cookie consent banner renders in the built output
- [ ] After merge + deploy: confirm hits appear in the GA4 property once the cookie banner is accepted
