### PR TITLE
Fix consent banner so Accept grants Google Analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,9 @@ extra:
     cookies:
       analytics:
         name: Google Analytics
-        checked: false
+        # Checked by default so the "Accept" button grants analytics; Material's
+        # Accept submits the current checkbox state, so an unchecked box = denied.
+        checked: true
     actions:
       - accept
       - reject


### PR DESCRIPTION
## Summary

Fixes a bug from PR #45 where Google Analytics received no data despite visitors clicking **Accept** on the cookie banner.

The analytics cookie was `checked: false` (default-unchecked). Material's **Accept** button submits the *current* checkbox state rather than ticking all boxes, so consent was stored without the analytics flag:

```js
__md_set("__consent", Object.fromEntries(Array.from(new FormData(form).keys()).map(e => [e, true])))
```

`FormData` only includes checked boxes, so analytics was omitted → `consent.analytics` falsy → `__md_analytics()` (which loads `gtag.js`) never ran. Granting analytics required Manage → tick the box → Accept, which effectively no one does.

This sets the analytics cookie to `checked: true`, so **Accept grants analytics and Reject still opts out** — the standard Material + GA pattern.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] Built banner renders `<input type="checkbox" name="analytics" checked>`
- [ ] After merge + deploy: in a fresh/incognito window, accept the banner and confirm a hit appears in GA4 → Reports → Realtime

> Note: visitors who already accepted under the old config won't be re-prompted (their cached consent has analytics denied) and won't be tracked until they clear site data. New visitors get the corrected behavior immediately.
