### PR TITLE
Add IGN 2024 and 2025 map collections

### DIFF
--- a/galleries.yml
+++ b/galleries.yml
@@ -10,6 +10,16 @@
 #   year        - challenge year the collection covers (required)
 #   description - one short sentence about it          (optional)
 
+- creator: IGN - Institut National de Géographie et d'Information Forestière
+  link: https://www.ign.fr/mag/30DayMapChallenge-30-jours-30-cartes-pour-celebrer-la-creativite-cartographique
+  year: 2025
+  description: A gallery of maps created by a bunch of IGN volunteers in 2025
+
+- creator: IGN - Institut National de Géographie et d'Information Forestière
+  link: https://www.ign.fr/mag/30-cartes-pour-voir-le-territoire-autrement
+  year: 2024
+  description: A gallery of maps created by a bunch of IGN volunteers in 2024
+
 - creator: Federica Gazzelloni
   link: https://fgazzelloni.github.io/30DayMapChallenge/
   year: 2025


### PR DESCRIPTION
Adds IGN's 2024 and 2025 map collections to `galleries.yml`.

This supersedes #49 by @bsaglio2001, with two fixes applied to that submission:

- **Apostrophe escaping** — the `creator` field used a doubled apostrophe (`d''Information`) in an unquoted YAML scalar, which YAML parses literally, so the rendered page showed `d''Information Forestière`. Changed to a single apostrophe so it renders correctly.
- **Trailing whitespace** removed.

The organisation name is kept exactly as the author wrote it.

Verified locally: `galleries.yml` parses to a single apostrophe and `mkdocs build --strict` passes.

## Test plan
- [ ] `build` check passes
- [ ] IGN entries appear under the 2025 and 2024 headings on the Map collections page, rendering as "d'Information"
