### PR TITLE
Remove Bluesky hashtag preview and simplify home-page countdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,8 @@ markers (it expects exactly 30 rows); run it with `python scripts/ical.py`
   - `docs/2020/`, `docs/2021/` and `docs/2022/` also have `dayNN_*.md` files listing
     most-liked tweets per day — a historical Twitter/X-era archive, no longer updated.
   - `docs/resources.md`, `docs/404.md`, `docs/imgs/`.
-  - `docs/stylesheets/extra.js` — opens external links in a new tab, drives the
-    home-page countdown, and pulls a small recent-Bluesky preview into the
-    "Across the web" section on the home page; `docs/stylesheets/gbextra.css`
+  - `docs/stylesheets/extra.js` — opens external links in a new tab and drives
+    the home-page countdown; `docs/stylesheets/gbextra.css`
     — site-wide custom styling.
     Both are wired in via `extra_javascript` / `extra_css` in `mkdocs.yml`.
   - `docs/manifest.webmanifest` and `docs/CNAME` — PWA manifest (referenced from
@@ -113,8 +112,9 @@ markers (it expects exactly 30 rows); run it with `python scripts/ical.py`
 
 `docs/index.md` includes a `#challenge-countdown` block (initially `hidden`) with
 two sub-blocks: one for the **themes announcement** (1 October) and one for the
-**challenge start** (1 November). `docs/stylesheets/extra.js` populates both each
-second, switches the themes block to a "Now available" banner once 1 October has
+**challenge start** (1 November). Each block shows a **days** and **hours**
+countdown (no minutes/seconds). `docs/stylesheets/extra.js` refreshes both once a
+minute, switches the themes block to a "Now available" banner once 1 October has
 passed, and switches the challenge block to a "Day N of 30" banner during
 November. After 1 December it advances to the next year's milestones. The script
 re-runs on Material's instant-navigation page swaps via `window.document$`, so

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,17 @@
 ## Daily social mapping project happening every November
 
+The official home of #30DayMapChallenge, a daily mapping challenge open to everyone. Every November, participants create one map a day for 30 days — each based on a different theme — and share them on social media using the hashtag `#30DayMapChallenge`.
+
+!!! info "Themes for 2026"
+    The 30 themes for the 2026 challenge will be announced later this year.
+    Themes from past challenges are kept in the **Archive** section.
+
 <div id="challenge-countdown" class="challenge-countdown" hidden>
   <div class="challenge-countdown__block" data-cd-block="themes">
     <div class="challenge-countdown__label" data-cd-label>Themes announced in</div>
     <div class="challenge-countdown__grid" data-cd-grid>
       <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-days>--</span><span class="challenge-countdown__unit">days</span></div>
       <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-hours>--</span><span class="challenge-countdown__unit">hours</span></div>
-      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-minutes>--</span><span class="challenge-countdown__unit">minutes</span></div>
-      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-seconds>--</span><span class="challenge-countdown__unit">seconds</span></div>
     </div>
     <div class="challenge-countdown__target" data-cd-target></div>
   </div>
@@ -16,18 +20,10 @@
     <div class="challenge-countdown__grid" data-cd-grid>
       <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-days>--</span><span class="challenge-countdown__unit">days</span></div>
       <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-hours>--</span><span class="challenge-countdown__unit">hours</span></div>
-      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-minutes>--</span><span class="challenge-countdown__unit">minutes</span></div>
-      <div class="challenge-countdown__cell"><span class="challenge-countdown__value" data-cd-seconds>--</span><span class="challenge-countdown__unit">seconds</span></div>
     </div>
     <div class="challenge-countdown__target" data-cd-target></div>
   </div>
 </div>
-
-The official home of #30DayMapChallenge, a daily mapping challenge open to everyone. Every November, participants create one map a day for 30 days — each based on a different theme — and share them on social media using the hashtag `#30DayMapChallenge`.
-
-!!! info "Themes for 2026"
-    The 30 themes for the 2026 challenge will be announced later this year.
-    Themes from past challenges are kept in the **Archive** section.
 
 ## How it works
 
@@ -52,14 +48,6 @@ Follow the `#30DayMapChallenge` hashtag wherever you already hang out:
   <a class="hashtag-chip" href="https://x.com/hashtag/30DayMapChallenge" target="_blank" rel="noopener">X</a>
   <a class="hashtag-chip" href="https://www.linkedin.com/feed/hashtag/?keywords=30daymapchallenge" target="_blank" rel="noopener">LinkedIn</a>
   <a class="hashtag-chip" href="https://www.instagram.com/explore/tags/30daymapchallenge/" target="_blank" rel="noopener">Instagram</a>
-</div>
-
-<div id="hashtag-preview" class="hashtag-preview" hidden aria-label="Recent #30DayMapChallenge posts on Bluesky">
-  <div class="hashtag-preview__header">
-    <span class="hashtag-preview__label">Latest on Bluesky</span>
-    <a class="hashtag-preview__more" href="https://bsky.app/hashtag/30DayMapChallenge" target="_blank" rel="noopener">See more →</a>
-  </div>
-  <div class="hashtag-preview__grid" data-hashtag-grid></div>
 </div>
 
 ## Code of Conduct

--- a/docs/stylesheets/extra.js
+++ b/docs/stylesheets/extra.js
@@ -44,17 +44,13 @@ for (var i = 0, linksLength = links.length; i < linksLength; i++) {
     var total = Math.floor(diff / 1000);
     var days = Math.floor(total / 86400);
     var hours = Math.floor((total % 86400) / 3600);
-    var minutes = Math.floor((total % 3600) / 60);
-    var seconds = total % 60;
 
     block.classList.remove("challenge-countdown__block--done", "challenge-countdown__block--banner");
     var grid = block.querySelector("[data-cd-grid]");
     if (grid) {
       grid.innerHTML =
         '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + days + '</span><span class="challenge-countdown__unit">days</span></div>' +
-        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(hours) + '</span><span class="challenge-countdown__unit">hours</span></div>' +
-        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(minutes) + '</span><span class="challenge-countdown__unit">minutes</span></div>' +
-        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(seconds) + '</span><span class="challenge-countdown__unit">seconds</span></div>';
+        '<div class="challenge-countdown__cell"><span class="challenge-countdown__value">' + pad(hours) + '</span><span class="challenge-countdown__unit">hours</span></div>';
     }
   }
 
@@ -119,7 +115,7 @@ for (var i = 0, linksLength = links.length; i < linksLength; i++) {
       var el = document.getElementById("challenge-countdown");
       if (!el) { clearInterval(timerId); timerId = null; return; }
       render(el);
-    }, 1000);
+    }, 60000);
   }
 
   if (document.readyState === "loading") {
@@ -131,147 +127,5 @@ for (var i = 0, linksLength = links.length; i < linksLength; i++) {
   // Material for MkDocs instant navigation: re-run on each page swap.
   if (typeof window.document$ !== "undefined" && window.document$.subscribe) {
     window.document$.subscribe(setup);
-  }
-})();
-
-// #30DayMapChallenge hashtag preview — pulls recent image posts from Bluesky's
-// public (no-auth) AppView. Fails silently if the API is unreachable.
-(function () {
-  var CACHE_KEY = "hashtagPreview.bsky.v1";
-  var CACHE_TTL_MS = 30 * 60 * 1000;
-  var TARGET_COUNT = 6;
-  var SEARCH_URL = "https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts" +
-                   "?q=" + encodeURIComponent("#30DayMapChallenge") +
-                   "&limit=30&sort=top";
-
-  function readCache() {
-    try {
-      var raw = window.localStorage.getItem(CACHE_KEY);
-      if (!raw) return null;
-      var obj = JSON.parse(raw);
-      if (!obj || !obj.t || (Date.now() - obj.t) > CACHE_TTL_MS) return null;
-      return obj.items;
-    } catch (e) { return null; }
-  }
-
-  function writeCache(items) {
-    try {
-      window.localStorage.setItem(CACHE_KEY,
-        JSON.stringify({ t: Date.now(), items: items }));
-    } catch (e) { /* ignore quota / privacy errors */ }
-  }
-
-  function pickImage(post) {
-    var e = post && post.embed;
-    if (!e) return null;
-    var images = e.images || (e.media && e.media.images);
-    if (!images || !images.length) return null;
-    return images[0];
-  }
-
-  function postUrl(post) {
-    var uri = post && post.uri;
-    var handle = post && post.author && post.author.handle;
-    if (!uri || !handle) return null;
-    var rkey = uri.split("/").pop();
-    if (!rkey) return null;
-    return "https://bsky.app/profile/" + encodeURIComponent(handle) +
-           "/post/" + encodeURIComponent(rkey);
-  }
-
-  function shape(posts) {
-    var out = [];
-    for (var i = 0; i < posts.length && out.length < TARGET_COUNT; i++) {
-      var p = posts[i];
-      var img = pickImage(p);
-      if (!img || !img.thumb) continue;
-      var url = postUrl(p);
-      if (!url) continue;
-      var handle = (p.author && p.author.handle) || "";
-      var name = (p.author && p.author.displayName) || handle;
-      out.push({
-        thumb: img.thumb,
-        alt: img.alt || "",
-        url: url,
-        handle: handle,
-        name: name
-      });
-    }
-    return out;
-  }
-
-  function render(grid, items) {
-    grid.innerHTML = "";
-    items.forEach(function (item) {
-      var a = document.createElement("a");
-      a.href = item.url;
-      a.target = "_blank";
-      a.rel = "noopener";
-      a.className = "hashtag-preview__card";
-      a.title = item.alt
-        ? item.name + " — " + item.alt
-        : "Post by " + item.name;
-
-      var img = document.createElement("img");
-      img.src = item.thumb;
-      img.alt = item.alt ||
-        ("Map by " + item.name + " (#30DayMapChallenge on Bluesky)");
-      img.loading = "lazy";
-      img.referrerPolicy = "no-referrer";
-
-      var meta = document.createElement("span");
-      meta.className = "hashtag-preview__meta";
-      meta.textContent = "@" + item.handle;
-
-      a.appendChild(img);
-      a.appendChild(meta);
-      grid.appendChild(a);
-    });
-  }
-
-  function reveal(container, grid, items) {
-    if (!items || !items.length) return;
-    render(grid, items);
-    container.hidden = false;
-  }
-
-  function init() {
-    var container = document.getElementById("hashtag-preview");
-    if (!container) return;
-    var grid = container.querySelector("[data-hashtag-grid]");
-    if (!grid || grid.dataset.loaded === "1") return;
-    grid.dataset.loaded = "1";
-
-    var cached = readCache();
-    if (cached && cached.length) {
-      reveal(container, grid, cached);
-      return;
-    }
-
-    if (typeof window.fetch !== "function") return;
-
-    window.fetch(SEARCH_URL, { headers: { "Accept": "application/json" } })
-      .then(function (r) {
-        if (!r.ok) throw new Error("HTTP " + r.status);
-        return r.json();
-      })
-      .then(function (data) {
-        if (!data || !Array.isArray(data.posts)) return;
-        var items = shape(data.posts);
-        if (!items.length) return;
-        writeCache(items);
-        reveal(container, grid, items);
-      })
-      .catch(function () { /* leave the section hidden */ });
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
-
-  if (typeof window.document$ !== "undefined" && window.document$.subscribe) {
-    window.document$.subscribe(init);
   }
 })();

--- a/docs/stylesheets/gbextra.css
+++ b/docs/stylesheets/gbextra.css
@@ -421,7 +421,7 @@ a.md-button:hover {
 
 .challenge-countdown__grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.4em;
 }
 
@@ -510,7 +510,7 @@ a.md-button:hover {
   .challenge-countdown__value { font-size: 1.4rem; }
 }
 
-/* ---------- Hashtag chips & Bluesky preview ----------------- */
+/* ---------- Hashtag chips ----------------------------------- */
 .hashtag-feed__chips {
   display: flex;
   flex-wrap: wrap;
@@ -551,108 +551,6 @@ a.md-button:hover {
   color: var(--md-accent-fg-color) !important;
   border-color: var(--md-accent-fg-color);
   background: rgba(251, 146, 60, 0.10);
-}
-
-.hashtag-preview {
-  margin: 1.6em 0 0.4em;
-}
-
-.hashtag-preview__header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1em;
-  margin-bottom: 0.7em;
-}
-
-.hashtag-preview__label {
-  font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--site-ink-soft);
-}
-
-[data-md-color-scheme="slate"] .hashtag-preview__label {
-  color: #b8b7b0;
-}
-
-.md-typeset .hashtag-preview__more {
-  font-size: 0.75rem;
-  text-decoration: none !important;
-  color: var(--site-accent);
-}
-
-.md-typeset .hashtag-preview__more:hover {
-  text-decoration: underline !important;
-}
-
-.hashtag-preview__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 0.55em;
-}
-
-.hashtag-preview__card {
-  position: relative;
-  display: block;
-  aspect-ratio: 1 / 1;
-  border-radius: 4px;
-  overflow: hidden;
-  background: var(--site-paper-soft);
-  text-decoration: none !important;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08),
-              0 4px 12px rgba(15, 23, 42, 0.06);
-  transition: transform 150ms ease, box-shadow 150ms ease;
-}
-
-.hashtag-preview__card:hover,
-.hashtag-preview__card:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14),
-              0 8px 24px rgba(15, 23, 42, 0.10);
-}
-
-.md-typeset .hashtag-preview__card img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 0;
-  box-shadow: none;
-  background: transparent;
-  display: block;
-}
-
-.hashtag-preview__meta {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  padding: 1.4em 0.6em 0.45em;
-  font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
-  font-size: 0.68rem;
-  font-weight: 500;
-  color: #fafaf7;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.78) 100%);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
-  letter-spacing: 0.01em;
-  pointer-events: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-[data-md-color-scheme="slate"] .hashtag-preview__card {
-  background: #1a1f27;
-}
-
-@media screen and (max-width: 48em) {
-  .hashtag-preview__grid {
-    grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
-  }
 }
 
 /* ---------- Responsive tweaks ------------------------------- */


### PR DESCRIPTION
Drop the non-functional Bluesky AppView preview (markup, fetch script,
and CSS). Move the countdown below the intro and themes note so the page
leads with what the challenge is, and trim the countdown to days/hours
(refreshing once a minute) instead of the busier days/hours/minutes/seconds.
