### PR TITLE
Improve SEO: add H1, per-page meta descriptions, and robots.txt

### DIFF
--- a/docs/2019/index.md
+++ b/docs/2019/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2019 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2019 Challenge
 
 The first #30DayMapChallenge ran throughout November 2019. The 30 daily themes

--- a/docs/2020/index.md
+++ b/docs/2020/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2020 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2020 Challenge
 
 The 2020 #30DayMapChallenge ran throughout November 2020. The 30 daily themes

--- a/docs/2021/index.md
+++ b/docs/2021/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2021 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2021 Challenge
 
 The 2021 #30DayMapChallenge ran throughout November 2021. The 30 daily themes

--- a/docs/2022/index.md
+++ b/docs/2022/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2022 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2022 Challenge
 
 The 2022 #30DayMapChallenge ran throughout November 2022. The 30 daily themes

--- a/docs/2023/index.md
+++ b/docs/2023/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2023 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2023 Challenge
 
 The 2023 #30DayMapChallenge ran throughout November 2023. The 30 daily themes

--- a/docs/2024/index.md
+++ b/docs/2024/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2024 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2024 Challenge
 
 The 2024 #30DayMapChallenge ran throughout November 2024. The 30 daily themes

--- a/docs/2025/index.md
+++ b/docs/2025/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The full list of 30 daily themes from the 2025 #30DayMapChallenge, the global
+  community mapping project held every November.
+---
+
 # 2025 Challenge
 
 The 2025 #30DayMapChallenge ran throughout November 2025. The 30 daily themes

--- a/docs/galleries/index.md
+++ b/docs/galleries/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Browse community galleries, portfolios and write-ups of #30DayMapChallenge maps
+  from 2019 onwards — and add your own collection so others can find it.
+---
+
 # Map collections
 
 Every November the #30DayMapChallenge community creates tens of thousands of

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,10 @@
-## Daily social mapping project happening every November
+---
+description: >-
+  The official home of #30DayMapChallenge — a free daily mapping challenge held
+  every November. Make one map a day for 30 themed days and share it with the world.
+---
+
+# Daily social mapping project happening every November
 
 The official home of #30DayMapChallenge, a daily mapping challenge open to everyone. Every November, participants create one map a day for 30 days — each based on a different theme — and share them on social media using the hashtag `#30DayMapChallenge`.
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Data sources, software, tools and tutorials to help you create maps for the
+  #30DayMapChallenge — whatever your skill level.
+---
+
 # Helpful resources
 
 ## Data

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://30daymapchallenge.com/sitemap.xml


### PR DESCRIPTION
- Promote the home page intro from H2 to H1 so the most important page
  has a proper top-level heading for search engines and the theme.
- Add front matter meta descriptions to the home, Map collections,
  resources and per-year archive pages for richer search snippets
  (previously only the site-wide site_description was used).
- Add docs/robots.txt pointing crawlers to the auto-generated sitemap.