### PR TITLE
Add Notes section using Material blog plugin

### DIFF
--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -1,0 +1,9 @@
+---
+title: Notes
+description: Occasional updates, announcements, and roundups of community maps.
+---
+
+# Notes
+
+Occasional updates, announcements, and roundups of community maps. Posted now
+and then, not on a fixed schedule.

--- a/docs/notes/posts/2026-06-06-a-few-site-updates.md
+++ b/docs/notes/posts/2026-06-06-a-few-site-updates.md
@@ -1,0 +1,21 @@
+---
+date: 2026-06-06          # post date, controls ordering
+categories:
+  - Announcement          # one of: Recap, Announcement, Community maps
+draft: false              # set true to hide while editing
+---
+
+# A few site updates
+
+A short note to kick off this section. The site has had some housekeeping
+lately: the Mapping resources page is refreshed, and the map collections
+page has been tidied up to make it easier to browse and add your own.
+
+This is also where notes like this will live from now on — occasional
+updates, the odd announcement, and roundups of maps from the community.
+Nothing on a fixed schedule.
+
+If you'd like to help organise the challenge, get in touch at
+[info@30daymapchallenge.com](mailto:info@30daymapchallenge.com).
+
+<!-- more -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,23 @@ plugins:
   # - mkdocstrings
   # - autolinks
   - macros
+  # "Notes" section, built with Material's built-in blog plugin.
+  # New posts: drop a Markdown file into docs/notes/posts/ with the front
+  # matter documented in the sample post. URLs read /notes/YYYY/MM/DD/slug/.
+  - blog:
+      blog_dir: notes
+      blog_toc: true
+      post_url_format: "{date}/{slug}"
+      post_url_date_format: yyyy/MM/dd
+      post_date_format: long
+      authors: false           # no per-author pages; not requested
+      pagination_per_page: 20   # generous, so a few posts stay on one page
+      categories_allowed:       # fixed set, no sprawling auto-generated list
+        - Recap
+        - Announcement
+        - Community maps
+  # The global RSS feed below (match_path ".*") already includes Notes posts,
+  # so readers can subscribe without a separate per-section feed.
   - rss:
       abstract_chars_count: 160
       date_from_meta:
@@ -261,3 +278,4 @@ nav:
     - "2019": 2019/index.md
 
   - Mapping resources: resources.md
+  - Notes: notes/index.md


### PR DESCRIPTION
## What

Adds a lightweight, infrequently-updated **Notes** section for annual recaps, announcements, and curated roundups of community maps. Built entirely on Material for MkDocs' built-in blog plugin (no custom solution), served at `/notes/`.

Designed so a low cadence reads as intentional: a few posts a year sit on a single page with nothing looking empty or broken.

## Files changed

- **`mkdocs.yml`**
  - Enables the built-in `blog` plugin as a section called **Notes** (`blog_dir: notes`, so URLs read `/notes/...`).
  - Date-based post URLs (`/notes/YYYY/MM/DD/slug/`), authors disabled, generous pagination (20/page), and a fixed category set: `Recap`, `Announcement`, `Community maps` (no auto-generated sprawl).
  - Adds `Notes` to the top nav, after `Mapping resources`.
- **`docs/notes/index.md`** — section landing page with a one-line plain-voice description.
- **`docs/notes/posts/2026-06-06-a-few-site-updates.md`** — the first post, with self-documenting front-matter comments to copy for future posts.

## Notes on RSS

The site's existing `rss` plugin is already configured site-wide (`match_path: ".*"`), so Notes posts are automatically included in the existing feed — readers can subscribe without a separate per-section feed and without any new dependency. A comment in `mkdocs.yml` documents this.

## Verification

`mkdocs build --strict` passes (exit 0, no warnings). Confirmed: Notes appears in nav, the index renders with the sample post, the post page renders at its date-based URL, and the `Announcement` category page generates. No custom CSS was needed.

## Adding future posts

Drop a `.md` file into `docs/notes/posts/` with the documented front matter (`date`, `categories`, `draft`). Nothing else to touch.

No existing pages, themes, or analytics config were changed.