### PR TITLE
Link the official LinkedIn page and polish site links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,9 @@ with your details and a maintainer will add the entry for you.
 ### 3. Get in touch
 
 If GitHub isn't your thing, reach out via
-[Topi's contact form](https://tjukanov.org/contact) or through the
-challenge's social channels linked from
+[Topi's contact form](https://tjukanov.org/contact), message the official
+[LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/), or use
+the challenge's other social channels linked from
 [30daymapchallenge.com](https://30daymapchallenge.com/).
 
 ## Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ with your details and a maintainer will add the entry for you.
 
 ### 3. Get in touch
 
-If GitHub isn't your thing, reach out via
+If GitHub isn't your thing, email
+[info@30daymapchallenge.com](mailto:info@30daymapchallenge.com), reach out via
 [Topi's contact form](https://tjukanov.org/contact), message the official
 [LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/), or use
 the challenge's other social channels linked from

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Every November, participants make one map a day for 30 days — each based on a 
 
 > **🌍 [30daymapchallenge.com](https://30daymapchallenge.com)** — themes, community map collections and mapping resources, all in one place.
 
+For announcements and highlights, follow the official [30DayMapChallenge LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/).
+
 The 30 themes for the **2026 challenge** will be announced later this year. Themes from past challenges are kept in [`archive/`](archive/).
 
 ## Explore the maps

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Every November, participants make one map a day for 30 days — each based on a 
 
 > **🌍 [30daymapchallenge.com](https://30daymapchallenge.com)** — themes, community map collections and mapping resources, all in one place.
 
-For announcements and highlights, follow the official [30DayMapChallenge LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/).
-
-The 30 themes for the **2026 challenge** will be announced later this year. Themes from past challenges are kept in [`archive/`](archive/).
+The 30 themes for the **2026 challenge** will be announced later this year. Themes from past challenges are kept in [`archive/`](archive/). Announcements are also posted on the official [30DayMapChallenge LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/).
 
 ## Explore the maps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,9 @@ There's also an official [30DayMapChallenge LinkedIn page](https://www.linkedin.
 for announcements and occasional highlights — but the hashtag is where the
 challenge happens, on whichever platform you prefer.
 
+Questions, ideas or anything else? Reach out at
+[info@30daymapchallenge.com](mailto:info@30daymapchallenge.com).
+
 ## Code of Conduct
 Whether you are a GIS expert or have never made a map before, everyone is welcome to participate.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,10 +45,7 @@ Every November mappers around the world share tens of thousands of maps. Browse 
 
 Since 2019, the community has shared **more than 50,000 maps** under the hashtag. As the challenge has spread across more and more platforms, pinning down exact totals has become nearly impossible — deeper community-maintained stats live in [Haifeng Niu's #30DayMapChallenge bot](https://github.com/hn303/30DayMapChallenge-Bot) and David Friggens' [2019–2020 metadata gallery](https://github.com/dakvid/30DayMapChallenge2020Metadata).
 
-For announcements and highlights straight from the organisers, follow the
-official **[30DayMapChallenge LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/)**.
-
-You can also follow the `#30DayMapChallenge` hashtag wherever you already hang out:
+Follow the `#30DayMapChallenge` hashtag wherever you already hang out:
 
 <div class="hashtag-feed__chips" markdown="0">
   <a class="hashtag-chip" href="https://bsky.app/hashtag/30DayMapChallenge" target="_blank" rel="noopener">Bluesky</a>
@@ -58,6 +55,10 @@ You can also follow the `#30DayMapChallenge` hashtag wherever you already hang o
   <a class="hashtag-chip" href="https://www.linkedin.com/feed/hashtag/?keywords=30daymapchallenge" target="_blank" rel="noopener">LinkedIn</a>
   <a class="hashtag-chip" href="https://www.instagram.com/explore/tags/30daymapchallenge/" target="_blank" rel="noopener">Instagram</a>
 </div>
+
+There's also an official [30DayMapChallenge LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/)
+for announcements and occasional highlights — but the hashtag is where the
+challenge happens, on whichever platform you prefer.
 
 ## Code of Conduct
 Whether you are a GIS expert or have never made a map before, everyone is welcome to participate.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,10 @@ Every November mappers around the world share tens of thousands of maps. Browse 
 
 Since 2019, the community has shared **more than 50,000 maps** under the hashtag. As the challenge has spread across more and more platforms, pinning down exact totals has become nearly impossible — deeper community-maintained stats live in [Haifeng Niu's #30DayMapChallenge bot](https://github.com/hn303/30DayMapChallenge-Bot) and David Friggens' [2019–2020 metadata gallery](https://github.com/dakvid/30DayMapChallenge2020Metadata).
 
-Follow the `#30DayMapChallenge` hashtag wherever you already hang out:
+For announcements and highlights straight from the organisers, follow the
+official **[30DayMapChallenge LinkedIn page](https://www.linkedin.com/company/30daymapchallenge/)**.
+
+You can also follow the `#30DayMapChallenge` hashtag wherever you already hang out:
 
 <div class="hashtag-feed__chips" markdown="0">
   <a class="hashtag-chip" href="https://bsky.app/hashtag/30DayMapChallenge" target="_blank" rel="noopener">Bluesky</a>

--- a/docs/notes/posts/2026-07-02-official-linkedin-page.md
+++ b/docs/notes/posts/2026-07-02-official-linkedin-page.md
@@ -10,9 +10,10 @@ draft: false              # set true to hide while editing
 The #30DayMapChallenge now has an official LinkedIn page:
 **[linkedin.com/company/30daymapchallenge](https://www.linkedin.com/company/30daymapchallenge/)**.
 
-Follow it for announcements — like the 2026 themes later this year — and
-highlights from the community. And of course, keep an eye on the
-[`#30DayMapChallenge` hashtag](https://www.linkedin.com/feed/hashtag/?keywords=30daymapchallenge)
-too, where a large share of the challenge maps are shared every November.
+To be clear: the challenge is **not moving to LinkedIn**. It stays what it has
+always been — a platform-agnostic, hashtag-driven challenge. Make your maps and
+share them wherever you like with `#30DayMapChallenge`; that's still the heart
+of it all. The page is simply an extra channel for announcements (like the 2026
+themes later this year) and occasional highlights from the community.
 
 <!-- more -->

--- a/docs/notes/posts/2026-07-02-official-linkedin-page.md
+++ b/docs/notes/posts/2026-07-02-official-linkedin-page.md
@@ -1,0 +1,18 @@
+---
+date: 2026-07-02          # post date, controls ordering
+categories:
+  - Announcement          # one of: Recap, Announcement, Community maps
+draft: false              # set true to hide while editing
+---
+
+# The challenge is now on LinkedIn
+
+The #30DayMapChallenge now has an official LinkedIn page:
+**[linkedin.com/company/30daymapchallenge](https://www.linkedin.com/company/30daymapchallenge/)**.
+
+Follow it for announcements — like the 2026 themes later this year — and
+highlights from the community. And of course, keep an eye on the
+[`#30DayMapChallenge` hashtag](https://www.linkedin.com/feed/hashtag/?keywords=30daymapchallenge)
+too, where a large share of the challenge maps are shared every November.
+
+<!-- more -->

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -18,7 +18,7 @@ You can use **whatever data you want.** Here are a few sources which could help 
 	- Natural Earth is a public domain map dataset available at 1:10m, 1:50m, and 1:110 million scales. Featuring tightly integrated vector and raster data, with Natural Earth you can make a variety of visually pleasing, well-crafted maps with cartography or GIS software.
 - [Free GIS Data](https://freegisdata.rtwilson.com/)
 	- The site contains a categorised list of links to over 500 sites providing freely available geographic datasets - all ready for loading into a Geographic Information System.
-- [OS OpenData](https://www.ordnancesurvey.co.uk/opendatadownload/products.html)
+- [OS OpenData](https://osdatahub.os.uk/downloads/open)
 	- Ordnance Survey Open Data for Great Britain. Includes general topographic map data at a range of scales; useful thematic data such as greenspace, terrain, roads and rivers; postcode and place name georeferencing.
 - [Humanitarian Data Exchange](https://data.humdata.org/)
 	- Interesting datasets from around the world.
@@ -62,7 +62,10 @@ The challenge is open to any software, but here’s a list of popular open-sourc
 	 
 
 ## Tutorials & helpful resources
-If you want to make maps with QGIS, this video is a great starting point. Check out also other videos by [Klas Karlson](https://www.youtube.com/playlist?list=PLNBeueOmuY163iwu4VpZdjqqdU1HkRTP_)
+
+Great starting points whether you're new to QGIS or to mapmaking in general:
+
+- [Klas Karlsson's QGIS videos](https://www.youtube.com/playlist?list=PLNBeueOmuY163iwu4VpZdjqqdU1HkRTP_)
 - [Steven Bernard's QGIS Introduction](https://www.youtube.com/playlist?list=PL7HotvlLKHCs9nD1fFUjSOsZrsnctyV2R)
 - [QGIS Tutorials by Ujaval Gandhi](https://www.qgistutorials.com/en/)
 - [3D Landscape Tutorial by Alasdair Rae](http://www.statsmapsnpix.com/2020/03/making-3d-landscape-and-city-models.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ extra:
     - icon: fontawesome/solid/square-rss
       link: https://30daymapchallenge.com/feed_rss_created.xml
       name: RSS feed
+    - icon: fontawesome/solid/envelope
+      link: mailto:info@30daymapchallenge.com
+      name: Email the organisers
   analytics:
     provider: google
     property: G-Z3RZNVKSNS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,9 @@ extra:
     - icon: fontawesome/brands/mastodon
       link: https://mapstodon.space/tags/30DayMapChallenge
       name: "#30DayMapChallenge on Mastodon"
+    - icon: fontawesome/brands/threads
+      link: https://www.threads.com/search?q=%2330DayMapChallenge&serp_type=tags
+      name: "#30DayMapChallenge on Threads"
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/hashtag/30DayMapChallenge
       name: "#30DayMapChallenge on X"
@@ -29,8 +32,11 @@ extra:
       link: https://www.instagram.com/explore/tags/30daymapchallenge/
       name: "#30DayMapChallenge on Instagram"
     - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/feed/hashtag/?keywords=30daymapchallenge
-      name: "#30DayMapChallenge on LinkedIn"
+      link: https://www.linkedin.com/company/30daymapchallenge/
+      name: 30DayMapChallenge on LinkedIn (official page)
+    - icon: fontawesome/solid/square-rss
+      link: https://30daymapchallenge.com/feed_rss_created.xml
+      name: RSS feed
   analytics:
     provider: google
     property: G-Z3RZNVKSNS


### PR DESCRIPTION
## What does this PR do?

Adds the new official LinkedIn page (https://www.linkedin.com/company/30daymapchallenge/) across the site, plus a few small non-breaking link fixes found during a site review. The hashtag-driven, platform-agnostic approach stays the primary framing everywhere — the LinkedIn page is presented as a secondary channel for announcements and highlights.

**LinkedIn:**
- Footer social icon now points at the official company page instead of the hashtag feed
- Home page "Across the web" section: hashtag chips stay first, with the official page mentioned after as an extra channel
- README mentions the page in the themes-announcement paragraph
- CONTRIBUTING "Get in touch" now offers messaging the LinkedIn page
- New Notes announcement post, stating explicitly that the challenge is **not** moving to LinkedIn

**Contact email:**
- info@30daymapchallenge.com added to CONTRIBUTING's get-in-touch options, mentioned on the home page, and linked as a footer envelope icon

**Site polish:**
- Footer icons: added Threads (already in the home-page chips) and the RSS feed (generated but previously unlinked)
- Mapping resources: fixed the dead Ordnance Survey OpenData link (now `osdatahub.os.uk/downloads/open`)
- Mapping resources: untangled the Tutorials intro sentence and made Klas Karlsson's playlist a proper list item

## Checklist

- [x] If adding a collection, I edited `galleries.yml` with `creator`, `link` and `year` — N/A, no collection added
- [x] Links are public and work without a login
- [x] The `build` check passes (`mkdocs build --strict` run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
