### PR TITLE
Add Atlas Guo (CartoGuophy) map collections (2024, 2025)

### DIFF
--- a/galleries.yml
+++ b/galleries.yml
@@ -948,3 +948,11 @@
 - creator: Topi Tjukanov
   link: https://tjukanov.org/30daymapchallenge
   year: 2019
+
+- creator: Atlas Guo (CartoGuophy)
+  link: https://cartoguophy.com/maps/30dmc_2025.html
+  year: 2025
+
+- creator: Atlas Guo (CartoGuophy)
+  link: https://cartoguophy.com/maps/30dmc_2024.html
+  year: 2024


### PR DESCRIPTION
## Summary

Adds two community **Map collections** to `galleries.yml`, submitted by **Atlas Guo (CartoGuophy)** via the gallery issue form:

| Year | Link | Source issue |
|------|------|--------------|
| 2025 | https://cartoguophy.com/maps/30dmc_2025.html | #60 |
| 2024 | https://cartoguophy.com/maps/30dmc_2024.html | #61 |

Both submissions were confirmed by the contributor as their own work, public, and accessible without a login. No description was provided in either submission, so the optional `description` field is omitted.

Closes #60
Closes #61

## Test plan

- [x] `galleries.yml` parses as valid YAML (216 entries total).
- [ ] `mkdocs build --strict` (CI `build` workflow) — renders the Map collections page.
- [ ] Reviewer to eyeball that the two `cartoguophy.com` links resolve (external links can't be checked from the build env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
