### PR TITLE
Add HeiGIT map collections (2024, 2025)

### DIFF
--- a/galleries.yml
+++ b/galleries.yml
@@ -956,3 +956,13 @@
 - creator: Atlas Guo (CartoGuophy)
   link: https://cartoguophy.com/maps/30dmc_2024.html
   year: 2024
+
+- creator: HeiGIT
+  link: https://heigit.org/looking-back-at-the-30daymapchallenge-2025/
+  year: 2025
+  description: Maps made by team members of HeiGIT (Heidelberg Institute for Geoinformation Technologies) for the 2025 challenge.
+
+- creator: HeiGIT
+  link: https://heigit.org/looking-back-at-the-30daymapchallenge-2024/
+  year: 2024
+  description: Maps made by team members of HeiGIT (Heidelberg Institute for Geoinformation Technologies) for the 2024 challenge.


### PR DESCRIPTION
## What does this PR do?

Adds the two community map collections submitted via the issue form:

- **HeiGIT** — https://heigit.org/looking-back-at-the-30daymapchallenge-2025/ (2025) — issue #63
- **HeiGIT** — https://heigit.org/looking-back-at-the-30daymapchallenge-2024/ (2024) — issue #64

Both entries were appended to `galleries.yml` with `creator` / `link` / `year` / `description`; the Map collections page picks them up automatically via the macros loop.

Closes #63
Closes #64

## Checklist

- [x] If adding a collection, I edited `galleries.yml` with `creator`, `link` and `year`
- [x] Links are public and work without a login (confirmed by the submitter and by the repo owner)
- [x] The `build` check passes (`mkdocs build --strict` run locally; both entries render on `/galleries/`)

